### PR TITLE
Cat 37896 rivercat onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dependency-reduced-pom.xml
 .bloop/
 .metals/
 metals.sbt
+.idea

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository is designed so that each directory in `app` is a Flink program. You can `cd` into one and run `./000_all.sh` to set up the program from scratch and run it. All you need as a prerequisite is `docker-compose` and an active docker installation (e.g. [Docker Desktop](https://www.docker.com/products/docker-desktop)).
 
 For instance, `cd app/quickstart-scala ; ./000_all.sh` will run a word count on
-a cluster on your local machine and print the result to stdout. Within that `quickstart-scala`, project tweak the code in the `override_code_to_copy_into_flinklabqs`, and run the `./000_all.sh` script again to see your changes.
+a cluster on your local machine and print the result to stdout. Within that `quickstart-scala` project, tweak the code in the `override_code_to_copy_into_flinklabqs`, and run the `./000_all.sh` script again to see your changes.
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       ENABLE_BUILT_IN_PLUGINS: flink-s3-fs-hadoop-1.12.5.jar
       FLINK_CONF_DIR: ${FLINK_CONF_DIR:-/opt/flink/conf.local}
   console:
+    platform: linux/amd64
     build:
       context: ./
       dockerfile: Dockerfile-console


### PR DESCRIPTION
Fixed a typo, added `.idea` folder to `.gitignore`, and added support for Apple Silicon.

Without the change in `docker-compose.yml`, I was getting the following error when running `docker-compose build`:
```
jobmanager uses an image, skipping
taskmanager uses an image, skipping
zookeeper uses an image, skipping
kafka uses an image, skipping
minio uses an image, skipping
Building console
[+] Building 2.1s (5/5) FINISHED
 => [internal] load build definition from Dockerfile-console                                                                                0.0s
 => => transferring dockerfile: 45B                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                           0.0s
 => => transferring context: 2B                                                                                                             0.0s
 => CANCELED [internal] load metadata for docker.io/library/maven:3.8-jdk-11                                                                2.0s
 => ERROR [internal] load metadata for docker.io/library/flink:1.12.5-scala_2.11-java11                                                     2.0s
 => CANCELED [internal] load metadata for docker.io/minio/mc:latest                                                                         2.0s
------
 > [internal] load metadata for docker.io/library/flink:1.12.5-scala_2.11-java11:
------
failed to solve with frontend dockerfile.v0: failed to create LLB definition: no match for platform in manifest sha256:2a99205168b4a764736a03fe041650803edd64b3b03b6f33f413e98f3a78c2c5: not found
ERROR: Service 'console' failed to build : Build failed 
```
This answer from StackOverflow solved it for me: https://stackoverflow.com/a/71156757, but I didn't test it on non-apple silicon macs. 
